### PR TITLE
Change how error is logged

### DIFF
--- a/finddata/publish_plot.py
+++ b/finddata/publish_plot.py
@@ -219,7 +219,7 @@ def plot1d(
         try:
             return publish_plot(instrument, run_number, files={"file": plot_div})
         except:  # noqa: E722
-            logging.error("Publish plot failed: %s", sys.exc_value)
+            logging.exception("Publish plot failed:")
             return None
     else:
         return plot_div
@@ -315,7 +315,7 @@ def plot_heatmap(
         try:
             return publish_plot(instrument, run_number, files={"file": plot_div})
         except:  # noqa: E722
-            logging.error("Publish plot failed: %s", sys.exc_value)
+            logging.exception("Publish plot failed:")
             return None
     else:
         return plot_div


### PR DESCRIPTION
By logging as an exception the stacktrace is also included. This also removes a bug with using the `sys` module in scopes where it hasn't been imported.

# Long description of the changes:

The error that appeared in [HB2C (probably be rerun by now)](https://monitor.sns.gov/report/hb2c/1364327/) is `NameError: name 'sys' is not defined`. The fuller context is 
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/anaconda/envs/mantid-dev/lib/python3.10/site-packages/finddata/publish_plot.py", line 247, in plot_heatmap
    return publish_plot(instrument, run_number, files={'file': plot_div})
  File "/opt/anaconda/envs/mantid-dev/lib/python3.10/site-packages/finddata/publish_plot.py", line 112, in publish_plot
    response = requests.post(url, data={'username': config.publisher_username,
  File "/opt/anaconda/envs/mantid-dev/lib/python3.10/site-packages/requests/api.py", line 115, in post
    return request("post", url, data=data, json=json, **kwargs)
  File "/opt/anaconda/envs/mantid-dev/lib/python3.10/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/opt/anaconda/envs/mantid-dev/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/opt/anaconda/envs/mantid-dev/lib/python3.10/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/opt/anaconda/envs/mantid-dev/lib/python3.10/site-packages/requests/adapters.py", line 700, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='livedata.sns.gov', port=443): Max retries exceeded with url: /plots/HB2C/1364327/upload_plot_data/
 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fd01a6c5bd0>: Failed to establish a new connection: [Errno 111] Connection refus
ed'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/HFIR/HB2C/shared/autoreduce/reduce_HB2C.py", line 812, in <module>
    plot_heatmap(run_number,
  File "/opt/anaconda/envs/mantid-dev/lib/python3.10/site-packages/finddata/publish_plot.py", line 249, in plot_heatmap
    logging.error("Publish plot failed: %s", sys.exc_value)
NameError: name 'sys' is not defined
```
which points out that when handling an error from publishing a plot (e.g. livedata is down), it tries an outdated logging method with an no-longer-existing variable on the `sys` object. As a fix, this just uses `logger.exception` which will give more details than the previous method.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
