### PR TITLE
Pin plotly to v5 and add a test in the conda package

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -37,9 +37,11 @@ requirements:
   run:
     - python
     - urllib3
-    - plotly
+    - plotly<6
 
 test:
+  imports:
+    - finddata.publish_plot
   commands:
     - finddata --help
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,4 +17,4 @@ dependencies:
   - toml
   - versioningit
   - urllib3
-  - plotly
+  - plotly<6


### PR DESCRIPTION
Plot.ly v6 changes the integer type for 1d plots which makes the plots be empty. Pin to v5 in order to avoid this issue.