### PR TITLE
Bump statically written version to v0.10.1

### DIFF
--- a/finddata.spec
+++ b/finddata.spec
@@ -6,7 +6,7 @@
 
 Summary: %{summary}
 Name: python-%{srcname}
-Version: 0.10.0
+Version: 0.10.1
 Release: %{release}%{?dist}
 Source: %{srcname}-%{version}.tar.gz
 License: MIT

--- a/pyproject.patch
+++ b/pyproject.patch
@@ -7,8 +7,8 @@ index ac7ebfb..adf8c09 100644
  name = "finddata"
  description = "A program to find data files using ONCat"
 -dynamic = ["version"]
--#version = "0.10.0"
-+version = "0.10.0"
+-#version = "0.10.1"
++version = "0.10.1"
  #requires-python = ">=3.10"
  dependencies = [
    # list all runtime dependencies here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "finddata"
 description = "A program to find data files using ONCat"
 dynamic = ["version"]
-#version = "0.10.0"
+#version = "0.10.1"
 #requires-python = ">=3.10"
 dependencies = [
   # list all runtime dependencies here


### PR DESCRIPTION
Since rpms are involved and they don't handle dynamic versioning.... this changes the static version numbers in all the appropriate places.
```sh
$ ./rpmbuild.sh
...
$ rpm -qilRp ~/rpmbuild/RPMS/noarch/python3.11-finddata-0.10.1-1.el9.noarch.rpm
Name        : python3.11-finddata
Version     : 0.10.1
Release     : 1.el9
Architecture: noarch
Install Date: (not installed)
Group       : Development/Libraries
Size        : 46225
License     : MIT
Signature   : (none)
Source RPM  : python-finddata-0.10.1-1.el9.src.rpm
Build Date  : Thu 06 Feb 2025 01:49:50 PM EST
Build Host  : ndav.sns.gov
Relocations : /usr 
Packager    : Peter F. Peterson
Vendor      : Pete Peterson <petersonpf@ornl.gov>
URL         : https://github.com/neutrons/finddata
Summary     : Find data files using ONCat
Description :
Finddata uses ONCat to locate the full path of files on the NScD clusters.
/usr/bin/python3.11
...
```