### PR TITLE
Add toml formatting and copy the pixi lockfile fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autofix_prs: true
-  skip: [pixi-lock-check]
+exclude: "^pixi.lock$"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -28,10 +28,15 @@ repos:
     rev: v0.17.2
     hooks:
       - id: yamlfmt
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+      - id: taplo-lint
   - repo: local
     hooks:
       - id: pixi-lock-check
         name: pixi-lock-check
         entry: bash -c "PATH=$HOME/.pixi/bin:$PATH pixi lock --check"
-        stage: pre-push
+        stages: [pre-push]
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ci:
   autofix_prs: true
+  skip: [taplo-lint]
 exclude: "^pixi.lock$"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -32,7 +33,7 @@ repos:
     rev: v0.9.3
     hooks:
       - id: taplo-format
-      - id: taplo-lint
+      - id: taplo-lint # makes web calls so can't be used in CI
   - repo: local
     hooks:
       - id: pixi-lock-check

--- a/pixi.lock
+++ b/pixi.lock
@@ -872,8 +872,8 @@ packages:
   timestamp: 1741969612334
 - pypi: ./
   name: finddata
-  version: 0.11.0.dev28
-  sha256: bca2685c7a8a001f985de287ba81cf14bcc02f14c03a1e7c9d49806048c31c2c
+  version: 0.11.0.dev27
+  sha256: d3f1e2d99ba01ffd89a6078a641ad934d5d7c5cf07ac8c53617291bc097fecef
   requires_dist:
   - plotly<6.0
   - toml>=0.10,<0.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "finddata"
 authors = [
-    { name = "Pete Peterson", email = "petersonpf@ornl.gov" },
-    { name = "Chen Zhang", email = "zhangc@ornl.gov" },
+  { name = "Pete Peterson", email = "petersonpf@ornl.gov" },
+  { name = "Chen Zhang", email = "zhangc@ornl.gov" },
 ]
 description = "A program to find data files using ONCat"
 dynamic = ["version"]
@@ -65,12 +65,12 @@ pythonpath = [".", "src", "scripts", "finddata"]
 testpaths = ["tests"]
 python_files = ["test*.py"]
 norecursedirs = [
-    ".git",
-    "tmp*",
-    "_tmp*",
-    "__pycache__",
-    "*dataset*",
-    "*data_set*",
+  ".git",
+  "tmp*",
+  "_tmp*",
+  "__pycache__",
+  "*dataset*",
+  "*data_set*",
 ]
 markers = ["mymarker: example markers goes here"]
 
@@ -84,18 +84,18 @@ exclude = ["conftest.py"]
 
 [tool.ruff.lint]
 select = [
-    "A",
-    "ARG",
-    "ASYNC",
-    "BLE",
-    "C90",
-    "E",
-    "F",
-    "I",
-    "N",
-    "PT",
-    "UP032",
-    "W",
+  "A",
+  "ARG",
+  "ASYNC",
+  "BLE",
+  "C90",
+  "E",
+  "F",
+  "I",
+  "N",
+  "PT",
+  "UP032",
+  "W",
 ]
 ignore = ["F403", "F405", "N802", "N803", "C901", "N806"]
 
@@ -146,21 +146,21 @@ build-sdist = { cmd = "hatch build sdist", description = "Build the source distr
 build-pypi = { cmd = "hatch build", description = "Build the package for PyPI" }
 clean-pypi = { cmd = "rm -rf dist", description = "Clean the PyPI build artifacts" }
 publish-pypi = { cmd = "twine upload dist/*", description = "Publish the package to PyPI", depends-on = [
-    "build-pypi",
+  "build-pypi",
 ] }
 # Conda
 build-conda-command = { cmd = "pixi build", description = "Build the conda package command" }
 build-conda = { description = "Build the conda package", depends-on = [
-    "sync-version",
-    "build-conda-command",
-    "reset-version",
+  "sync-version",
+  "build-conda-command",
+  "reset-version",
 ] }
 clean-conda = { cmd = "rm finddata-*.conda", description = "Clean the conda build artifacts" }
 # MISC
 clean-all = { description = "Clean all build artifacts", depends-on = [
-    "reset-version",
-    "clean-pypi",
-    "clean-conda",
+  "reset-version",
+  "clean-pypi",
+  "clean-conda",
 ] }
 sync-version = { cmd = 'version=$(python -m versioningit); toml set tool.pixi.package.version "$version" --toml-path pyproject.toml', description = "Sync pyproject.toml version with Git version" }
 reset-version = { cmd = "toml set tool.pixi.package.version \"0.0.0\" --toml-path pyproject.toml", description = "Reset the package version to 0.0.0" }


### PR DESCRIPTION
This did reformat the `pyproject.toml` which, of course, invalidates the `pixi.lock`. The real changes are in the `.pre-commit-config.yaml`.