### PR TITLE
Mark pixi.lock as binary to prevent merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true
+
 finddata/_version.py export-subst


### PR DESCRIPTION
Without this there is more chance of merge conflicts when rebasing