### PR TITLE
Set the version statically in the pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include src/finddata finddata.bashcomplete README.md
 include src/finddata/cli.py
-include src/finddata/_version.py
+include src/finddata/__init__.py

--- a/pixi.lock
+++ b/pixi.lock
@@ -177,7 +177,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.8.17-h2f8d451_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.34.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
@@ -186,8 +185,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-      - pypi: https://files.pythonhosted.org/packages/2f/d8/7303ea38911759c1ee30cc5bc623ee85d3196b733c51fd6703c34290a8d9/regex-2025.9.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/fd/72/ca812976bdf9329c0fa641c4c4740b4183520ae4e30a1b3b88d5c8392658/toml_cli-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/37/c631f7a70f99eb095a6f502818c665a0e45b0bcd2dfe21b632ea0448cfc1/ty-0.0.1a8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: ./
       osx-arm64:
@@ -348,7 +345,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.8.17-haaa92d6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.34.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
@@ -357,8 +353,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py313h9734d34_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
-      - pypi: https://files.pythonhosted.org/packages/c7/d8/de4a4b57215d99868f1640e062a7907e185ec7476b4b689e2345487c1ff4/regex-2025.9.1-cp313-cp313-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/fd/72/ca812976bdf9329c0fa641c4c4740b4183520ae4e30a1b3b88d5c8392658/toml_cli-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/51/ea027f052b16dd6b8e2612a965be624a85dc80827200d53f72faf4af2af9/ty-0.0.1a8-py3-none-macosx_11_0_arm64.whl
       - pypi: ./
 packages:
@@ -874,8 +868,8 @@ packages:
   timestamp: 1755216353218
 - pypi: ./
   name: finddata
-  version: 0.12.0.dev4
-  sha256: 56627d72ae0d8f9837bebd2aec4bf505ad9154cc84a14357b34a97e9cdf01e99
+  version: 0.12.0
+  sha256: 3adadaece582ff503606469e84089583a053e35296c8c7fc3455e9be592133e0
   requires_dist:
   - urllib3>=2.2.3,<3
   requires_python: '>=3.9'
@@ -2738,16 +2732,6 @@ packages:
   - pkg:pypi/referencing?source=hash-mapping
   size: 51668
   timestamp: 1737836872415
-- pypi: https://files.pythonhosted.org/packages/2f/d8/7303ea38911759c1ee30cc5bc623ee85d3196b733c51fd6703c34290a8d9/regex-2025.9.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-  name: regex
-  version: 2025.9.1
-  sha256: 09a41dc039e1c97d3c2ed3e26523f748e58c4de3ea7a31f95e1cf9ff973fff5a
-  requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/c7/d8/de4a4b57215d99868f1640e062a7907e185ec7476b4b689e2345487c1ff4/regex-2025.9.1-cp313-cp313-macosx_11_0_arm64.whl
-  name: regex
-  version: 2025.9.1
-  sha256: 22213527df4c985ec4a729b055a8306272d41d2f45908d7bacb79be0fa7a75ad
-  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
   sha256: 8dc54e94721e9ab545d7234aa5192b74102263d3e704e6d0c8aa7008f2da2a7b
   md5: db0c6b99149880c8ba515cf4abe93ee4
@@ -2951,15 +2935,6 @@ packages:
   - pkg:pypi/toml?source=hash-mapping
   size: 22132
   timestamp: 1734091907682
-- pypi: https://files.pythonhosted.org/packages/fd/72/ca812976bdf9329c0fa641c4c4740b4183520ae4e30a1b3b88d5c8392658/toml_cli-0.7.0-py3-none-any.whl
-  name: toml-cli
-  version: 0.7.0
-  sha256: 49f460ead043a86cc859ef7d710a64b912ac3596700951c9fb18491382716907
-  requires_dist:
-  - regex>=2020.7.14
-  - tomlkit>=0.12.1
-  - typer>=0.3.2
-  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
   sha256: 040a5a05c487647c089ad5e05ad5aff5942830db2a4e656f1e300d73436436f1
   md5: 30a0a26c8abccf4b7991d590fe17c699
@@ -3228,20 +3203,6 @@ packages:
   purls: []
   size: 14210936
   timestamp: 1757591102491
-- conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
-  sha256: 4b9a3f6738ab6e241b12b2fe9258f7e051678b911ca0f0ab042becc29096ff51
-  md5: 57b96d99ac0f5a548f7001618db6a561
-  depends:
-  - importlib-metadata >=3.6
-  - packaging >=17.1
-  - python >=3.9
-  - tomli >=1.2,<3.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/versioningit?source=hash-mapping
-  size: 167034
-  timestamp: 1751113901223
 - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.34.0-pyhd8ed1ab_0.conda
   sha256: 398f40090e80ec5084483bb798555d0c5be3d1bb30f8bb5e4702cd67cdb595ee
   md5: 2bd6c0c96cfc4dbe9bde604a122e3e55

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
   { name = "Chen Zhang", email = "zhangc@ornl.gov" },
 ]
 description = "A program to find data files using ONCat"
-dynamic = ["version"]
+version = "0.12.0"
 requires-python = ">=3.9"
 license = { text = "MIT" }
 keywords = ["neutrons", "finddata", "ONCat"]
@@ -23,38 +23,7 @@ issues = "https://github.com/neutrons/finddata/issues"
 
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling", "versioningit"]
-
-# ------------------- #
-# Hatch configuration #
-# ------------------- #
-[tool.hatch.version]
-source = "versioningit"
-
-[tool.hatch.build.hooks.versioningit-onbuild]
-source-file = "src/finddata/_version.py"
-build-file = "finddata/_version.py"
-
-[tool.hatch.build]
-artifacts = ["src/finddata/_version.py"]
-
-# -------------------------- #
-# Versioningit configuration #
-# -------------------------- #
-[tool.versioningit.vcs]
-method = "git"
-default-tag = "0.0.1"
-
-[tool.versioningit.next-version]
-method = "minor"
-
-[tool.versioningit.format]
-distance = "{next_version}.dev{distance}"
-dirty = "{version}"
-distance-dirty = "{next_version}.dev{distance}"
-
-[tool.versioningit.write]
-file = "src/finddata/_version.py"
+requires = ["hatchling"]
 
 # -------------------- #
 # PyTest configuration #
@@ -116,24 +85,20 @@ channels = ["conda-forge", "https://prefix.dev/pixi-build-backends", "neutrons"]
 platforms = ["linux-64", "osx-arm64"]
 
 [tool.pixi.dependencies]
-toml = ">=0.10.2,<0.11"
 plot-publisher = ">=1.0,<2.0"
 
 [tool.pixi.pypi-dependencies]
 finddata = { path = ".", editable = true }
-toml-cli = ">=0.7.0,<0.8"
 ty = ">=0.0.1a8,<0.0.1a9"
 
 [tool.pixi.package]
 name = "finddata"
-version = "0.0.0" # placeholder, can be updated by task sync-version
 
 [tool.pixi.package.build]
 backend = { name = "pixi-build-python", version = "0.1.*" }
 
 [tool.pixi.package.host-dependencies]
 hatchling = "*"
-versioningit = "*"
 
 [tool.pixi.package.run-dependencies]
 plot-publisher = ">=1.0,<2.0"
@@ -148,34 +113,22 @@ publish-pypi = { cmd = "twine upload dist/*", description = "Publish the package
   "build-pypi",
 ] }
 # Conda
-build-conda-command = { cmd = "pixi build", description = "Build the conda package command" }
-build-conda = { description = "Build the conda package", depends-on = [
-  "backup-toml",
-  "sync-version",
-  "build-conda-command",
-  "reset-toml",
-] }
+build-conda = { cmd = "pixi build", description = "Build the conda package command" }
 clean-conda = { cmd = "rm finddata-*.conda", description = "Clean the conda build artifacts" }
 # MISC
 clean-all = { description = "Clean all build artifacts", depends-on = [
-  "reset-toml",
   "clean-pypi",
   "clean-conda",
 ] }
-sync-version = { cmd = 'version=$(python -m versioningit); toml set tool.pixi.package.version "$version" --toml-path pyproject.toml', description = "Sync pyproject.toml version with Git version" }
-backup-toml = { cmd = "cp pyproject.toml pyproject.toml.bak", description = "Backup the pyproject.toml file" }
-reset-toml = { cmd = "cp pyproject.toml.bak pyproject.toml; rm pyproject.toml.bak", description = "Reset the pyproject.toml file to the original state" }
 audit-deps = { cmd = "pip-audit --local -s osv" }
 
 [tool.pixi.feature.package.dependencies]
 anaconda-client = ">=1.13.0,<2"
 twine = ">=6.1.0,<7"
-versioningit = "*"
 hatch = "*"
 
 [tool.pixi.feature.developer.dependencies]
 pip = "*"
-versioningit = "*"
 pre-commit = "*"
 argcomplete = "*"
 pip-audit = ">=2.9.0,<3"

--- a/src/finddata/__init__.py
+++ b/src/finddata/__init__.py
@@ -1,8 +1,8 @@
-# finddata version
-try:
-    from ._version import __version__  # noqa: F401
-except ImportError:
-    __version__ = "unknown"
+# finddata version - from pacakge metadata
+from importlib import metadata
+
+__version__ = metadata.version("finddata")
+del metadata
 
 # Import publish_plot functions from external package if available
 # This maintains backward compatibility while removing local duplicate code


### PR DESCRIPTION
versioningit doesn't exist as a system package in rhel9 so building an rpm required editing the pyproject.toml that was included in the source distribution. This changes to statically setting the version in the pyproject.toml, then dynamically getting it at runtime for users.

To keep the scope small, building the rpm was not modified and is likely broken. The rpm will be fixed in a separate package.

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [x] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
Build all of the packages and do a check of their contents. The tasks are
* `build-sdist`
* `build-pypi`
* `build-conda`

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
