### PR TITLE
Get rpm building again

### DIFF
--- a/finddata.spec
+++ b/finddata.spec
@@ -2,11 +2,11 @@
 %global summary Find data files using ONCat
 %define release 1
 # default python3=python3.9 on rhel9 which is too old
-%define python3_pkgversion 3
+#define python3_pkgversion 3
 
 Summary: %{summary}
 Name: python-%{srcname}
-Version: 0.11.2
+Version: %{version}
 Release: %{release}%{?dist}
 Source: %{srcname}-%{version}.tar.gz
 License: MIT
@@ -17,6 +17,7 @@ BuildArch: noarch
 Vendor: Pete Peterson <petersonpf@ornl.gov>
 Url: https://github.com/neutrons/finddata
 Obsoletes: python3-finddata < 0.10
+Obsoletes: python3.11-finddata < 0.12
 
 %description
 Finddata uses ONCat to locate the full path of files on the NScD clusters.
@@ -24,22 +25,20 @@ Finddata uses ONCat to locate the full path of files on the NScD clusters.
 %package -n python%{python3_pkgversion}-%{srcname}
 Summary:  %{summary}
 Requires: python%{python3_pkgversion}
+Requires: python%{python3_pkgversion}-argcomplete
 Requires: python%{python3_pkgversion}-urllib3
 Requires: bash
 Requires: bash-completion
-#Requires: python{python3_pkgversion}-argcomplete
-%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 
-BuildRequires: python%{python3_pkgversion}-devel
-BuildRequires: python%{python3_pkgversion}-wheel
 BuildRequires: python%{python3_pkgversion}-pip
+BuildRequires: python%{python3_pkgversion}-hatchling
 
 %description -n python%{python3_pkgversion}-%{srcname}
 Finddata uses ONCat to locate the full path of files on the NScD clusters.
 
 # unpack tarball and apply patchfile - add -v to see individual commands
 %prep
-%autosetup -p1
+%autosetup -p1 -n %{srcname}-%{version}
 
 %build
 %pyproject_wheel

--- a/pixi.lock
+++ b/pixi.lock
@@ -869,9 +869,9 @@ packages:
 - pypi: ./
   name: finddata
   version: 0.12.0
-  sha256: 3adadaece582ff503606469e84089583a053e35296c8c7fc3455e9be592133e0
+  sha256: d8e219d855996792deee094799a4266bb9f0da9ff32882a1570134fc395321cf
   requires_dist:
-  - urllib3>=2.2.3,<3
+  - urllib3
   requires_python: '>=3.9'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhd8ed1ab_0.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.9"
 license = { text = "MIT" }
 keywords = ["neutrons", "finddata", "ONCat"]
 readme = "README.md"
-dependencies = ["urllib3>=2.2.3,<3"]
+dependencies = ["urllib3"] # let pypi and system packages figure out things
 
 [project.scripts]
 finddata = "finddata.cli:main"

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -1,59 +1,23 @@
 #!/bin/sh
-# get the version from the spec file
 SPECFILE="$(dirname "$(realpath "$0")")/finddata.spec"
-echo "Finding version from ${SPECFILE}"
 
-VERSION="$(grep Version "${SPECFILE}" | awk '{print $2}')"
-if [ -z "${VERSION}" ]; then
-    echo "Failed to determine the version from ${SPECFILE}"
-    exit 127
-fi
-echo "Version is ${VERSION}"
-
-# check that pixi is installed
-if [ ! "$(command -v pixi)" ]; then
-    echo "This script requires pixi to be installed"
-    exit 127
-fi
+# get the version from the pyproject.toml file
+VERSION=$(pixi run python -c "from importlib import metadata;print(metadata.version('finddata'))")
+echo "version in pyproject.toml is ${VERSION}"
 
 # create the tarball
 echo "building sdist..."
 pixi run build-sdist || exit 127
 
-TARBALL_SRC="finddata-$(pixi run versioningit).tar.gz" # created
-TARBALL_TGT="finddata-${VERSION}.tar.gz" # what we want
-# fixup the tarball if necessary
-if [ "${TARBALL_SRC}" != "${TARBALL_TGT}" ]; then
-    echo "cleaning up tarball"
-    rm -rf "finddata-${VERSION}"
-    mkdir "python-finddata-${VERSION}"
-
-    echo "unpacking ${TARBALL_SRC}"
-    tar xzf "sdist/${TARBALL_SRC}" --strip 1 -C "python-finddata-${VERSION}" || exit 127
-    rm "${TARBALL_SRC}"
-
-    # set a fixed version number
-    echo "modify the pyproject.toml"
-    pixi run toml unset project.dynamic --toml-path python-finddata-"${VERSION}"/pyproject.toml || exit 127
-    pixi run toml set project.version "${VERSION}" --toml-path python-finddata-"${VERSION}"/pyproject.toml || exit 127
-    pixi run toml unset tool.versioningit --toml-path python-finddata-"${VERSION}"/pyproject.toml || exit 127
-    pixi run toml unset tool.hatch.version --toml-path python-finddata-"${VERSION}"/pyproject.toml || exit 127
-    pixi run toml unset tool.hatch.build.hooks.versioningit-onbuild --toml-path python-finddata-"${VERSION}"/pyproject.toml || exit 127
-    # remove dependencies since rpm will handle them
-    pixi run toml unset project.dependencies --toml-path python-finddata-"${VERSION}"/pyproject.toml || exit 127
-
-    echo "create tarball with correct name"
-    tar czf "${TARBALL_TGT}" "python-finddata-${VERSION}" || exit 127
-    rm -rf "python-finddata-${VERSION}"
-fi
 
 # setup rpm directories for building - renames the tarball
+TARBALL_SRC="finddata-${VERSION}.tar.gz" # created
 mkdir -p "${HOME}"/rpmbuild/SOURCES
-cp "${TARBALL_TGT}" "${HOME}/rpmbuild/SOURCES/${TARBALL_TGT}" || exit 127
+cp dist/"${TARBALL_SRC}" "${HOME}"/rpmbuild/SOURCES/"${TARBALL_SRC}" || exit 127
 
 # build the rpm and give instructions
 echo "building the rpm"
-rpmbuild -ba finddata.spec || exit 127
+rpmbuild -ba "${SPECFILE}" --define "version ${VERSION}" || exit 127
 
 # give people a hint on how to verify the rpm
 # shellcheck disable=SC1083


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [x] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
On ndav: `./rpmbuild.sh` and verify the rpm contents using the command printed at the end of the build.

# References
[EWM13162](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=13162)

